### PR TITLE
[Style] 버튼 말풍선 컴포넌트 구현

### DIFF
--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -1,0 +1,13 @@
+import { Bubble } from "@/components/ui/Bubble";
+
+export default function page() {
+  return (
+    <div className="flex min-h-screen justify-center items-center">
+      <Bubble size="lg">
+        대나무 행주 모임이
+        <br />
+        생성되었습니다 🎉
+      </Bubble>
+    </div>
+  );
+}

--- a/src/components/ui/Bubble.tsx
+++ b/src/components/ui/Bubble.tsx
@@ -10,13 +10,17 @@ export const Bubble = ({
   className = "",
 }: BubbleProps) => {
   const baseStyle =
-    "text-center w-[280px] px-6 py-6 text-[color:var(--color-black)] bg-[color:var(--color-white)] rounded-lg";
+    "text-center w-[280px] px-6 py-6 text-[color:var(--color-black)] bg-[color:var(--color-white)] rounded-lg ";
   const sizeStyles = {
     sm: "text-xs",
     lg: "text-base",
   };
   return (
-    <div className="flex flex-col items-center drop-shadow-[0_8px_16px_rgba(27,33,44,0.12)]">
+    <div
+      className="flex flex-col items-center drop-shadow-[0_8px_16px_rgba(27,33,44,0.12)] animate-bounce"
+      // style={{ animationDuration: "100ms" }}
+      // 개 촐싹버전
+    >
       <div className={`${baseStyle} ${sizeStyles[size]} ${className}`}>
         {children}
       </div>


### PR DESCRIPTION
## #️⃣ Issue Number

<!-- 관련된 이슈 번호를 작성해주세요. 예: #12, #34 없다면 무시 -->

---

## 📝 요약(Summary)

> 말풍선(Bubbe) 공통 컴포넌트 구현

- 텍스트 크기별 두 가지 사이즈 지원 (sm/lg) //  기본값 "sm"
- 추가 className 및 버튼의 기본 속성 전달 가능
- 말풍선의 텍스트는 `<br/>`을 통해 줄바꿈

```ts
<Bubble size="sm">복잡한 일정 조율, 한 번에 끝내세요🔥</Bubble>

<Bubble size="lg">대나무 행주 모임이 <br/>생성되었습니다 🎉</Bubble>
```
---

## 🛠️ PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📸스크린샷 (선택)
![Screenshot 2025-07-08 at 9 49 05 AM](https://github.com/user-attachments/assets/8a711ea7-9f37-473a-904e-f8736813b807)

![Screenshot 2025-07-08 at 9 31 09 AM](https://github.com/user-attachments/assets/066dde6f-4b3a-4175-8055-502fa250ab7a)

---

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
