### PR TITLE
[Style] 카카오 지도 컴포넌트 추가

### DIFF
--- a/src/components/landing/Landing.tsx
+++ b/src/components/landing/Landing.tsx
@@ -1,14 +1,9 @@
 "use client";
 
-import Map from "../feature/Map";
-
 const Landing = () => {
   return (
     <>
       <div>Landing</div>
-      <div className="w-375 mx-10">
-        <Map />
-      </div>
     </>
   );
 };


### PR DESCRIPTION
## #️⃣ Issue Number

---

## 📝 요약(Summary)

카카오 지도에 커스텀 마크를 찍을 수 있는 기능 추가

---

## 🛠️ PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📸스크린샷 (선택)

![image](https://github.com/user-attachments/assets/c50bc2b6-603c-45c7-9e9c-ffc595ee213d)
![image](https://github.com/user-attachments/assets/e7b7932c-baee-4d9a-aba5-0e4c9dd1287c)

마커 false
![image](https://github.com/user-attachments/assets/3d6f5480-e9e6-4749-9594-1a504d078816)



---

## 💬 공유사항 to 리뷰어
`<Map latitude={37.5058098} longitude={126.7531869} />`
경도와 위도를 props로 주면 해당 위치에 마커가 찍힙니다.

props 없이 사용하면 서초 그렙 사무실이 디폴트로 마커가 찍힙니다.
마커 표시 안하고 싶으면 showMarker = {false}로 주면 됩니다.

