### PR TITLE
[Refactor] 바텀 시트 적용, SubwaySeacrh에서 page 렌더링으로 이동, ui 수정

### DIFF
--- a/src/app/schedule/[Id]/election/start-point/page.tsx
+++ b/src/app/schedule/[Id]/election/start-point/page.tsx
@@ -6,12 +6,15 @@ import { kakaoSearch } from "@/types/kakaoSearch";
 import Map from "@/components/feature/kakaoMap/Map";
 import HeaderTop from "@/components/layout/HeaderTop";
 import GroupHeader from "@/components/layout/GroupHeader";
+import BottomSheet from "@/components/ui/BottomSheet";
+import Header from "@/components/layout/Header";
 
 const StartPoint = () => {
   const [selectedStation, setSelectedStation] = useState<kakaoSearch | null>(
     null
   );
   const [isSmOrLarger, setIsSmOrLarger] = useState(false);
+  const [isSheetOpen, setIsSheetOpen] = useState(true);
 
   useEffect(() => {
     const checkScreenSize = () => {
@@ -22,8 +25,15 @@ const StartPoint = () => {
     return () => window.removeEventListener("resize", checkScreenSize);
   }, []);
 
+  const selectStationHandler = (station: kakaoSearch) => {
+    setSelectedStation(station);
+    //setIsSheetOpen(false);
+  };
   return (
-    <main className="flex flex-col h-screen relative max-w-[1024px] mx-auto">
+    <main className="flex flex-col h-screen relative w-full mx-auto">
+      <div className="hidden sm:block">
+        <Header type="blue" />
+      </div>
       {isSmOrLarger ? (
         <GroupHeader
           groupName="카츠오모이 가는날"
@@ -40,9 +50,20 @@ const StartPoint = () => {
           latitude={selectedStation ? Number(selectedStation.y) : 37.4849424}
         />
       </div>
-      <div className="w-[740px]">
-        <SubwaySearch onSelectStation={setSelectedStation} />
-      </div>
+      <BottomSheet
+        isOpen={isSheetOpen}
+        setIsOpen={setIsSheetOpen}
+        snapPoints={[0.4, 0.22, 0.15]}
+        initialSnap={1}
+        className="px-4"
+      >
+        {(snapTo) => (
+          <SubwaySearch
+            onSelectStation={selectStationHandler}
+            snapTo={snapTo}
+          />
+        )}
+      </BottomSheet>
     </main>
   );
 };

--- a/src/components/feature/kakaoMap/SubwaySearch.tsx
+++ b/src/components/feature/kakaoMap/SubwaySearch.tsx
@@ -1,24 +1,22 @@
 "use client";
 
-import BottomSheet from "@/components/ui/BottomSheet";
 import Input from "@/components/ui/Input";
-import { useEffect, useState } from "react";
 import { Search } from "lucide-react";
 import SubwaySearchResultList from "@/components/ui/SubwaySearchResultList";
 import { searchSubwayStation } from "@/app/utils/searchSubwayStation";
 import { kakaoSearch } from "@/types/kakaoSearch";
 import { Button } from "@/components/ui/Button";
 import { X } from "lucide-react";
+import { useState } from "react";
 
 const REST_API_KEY = process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY as string;
 
 interface SubwaySearchProps {
   onSelectStation: (station: kakaoSearch) => void;
+  snapTo?: (i: number) => void;
 }
 
-const SubwaySearch = ({ onSelectStation }: SubwaySearchProps) => {
-  const [isOpen, setIsOpen] = useState(true);
-  const [mounted, setMounted] = useState(false);
+const SubwaySearch = ({ onSelectStation, snapTo }: SubwaySearchProps) => {
   const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(false);
   const [results, setResults] = useState<kakaoSearch[]>([]);
@@ -29,9 +27,9 @@ const SubwaySearch = ({ onSelectStation }: SubwaySearchProps) => {
   //쿼리초기화, 검색 결과 초기화 추가 필요
 
   const selectHandler = ({ station }: { station: kakaoSearch }) => {
-    //console.log("선택된 역:", station);
     setSelectedStation(station);
     onSelectStation(station);
+    if (snapTo) snapTo(2);
   };
 
   const searchHandler = async () => {
@@ -40,77 +38,78 @@ const SubwaySearch = ({ onSelectStation }: SubwaySearchProps) => {
     try {
       const data = await searchSubwayStation(query, REST_API_KEY);
       setResults(data.documents);
+      if (snapTo) snapTo(1);
     } catch (e) {
       console.log("fail", e);
     }
     setLoading(false);
   };
 
-  useEffect(() => {
-    setMounted(true);
-  }, []);
+  const resetHandler = () => {
+    setSelectedStation(null);
+    setQuery("");
+    setResults([]);
+    if (snapTo) snapTo(0);
+  };
 
-  if (!mounted) return null;
   return (
-    <BottomSheet isOpen={isOpen} snapPoints={544} setIsOpen={setIsOpen}>
-      <div className="w-full flex flex-col items-center justify-center">
-        <div className="w-full max-w-[700px] pb-8 flex flex-col mx-auto">
-          {!selectedStation ? (
-            <>
-              <h1 className="text-base font-semibold py-8 text-[var(--color-black)] text-center">
-                출발할 위치를 입력해주세요
-              </h1>
-              <div className="flex flex-col w-full min-h-41 gap-4">
-                <Input
-                  icon={<Search className="w-4 h-4" onClick={searchHandler} />}
-                  placeholder="출발지 검색"
-                  value={query}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                    setQuery(e.target.value)
-                  }
-                  fullWidth={true}
-                  onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
-                    if (e.key === "Enter") searchHandler();
-                  }}
-                />
-                <SubwaySearchResultList
-                  results={results}
-                  onSelect={selectHandler}
-                  keyword={query}
-                />
-                {loading && <div className="text-center py-2">검색 중</div>}
-              </div>
-            </>
-          ) : (
-            <div className="flex flex-col w-full items-center py-7 justify-center gap-4">
-              <div className="flex w-full justify-between">
-                <div className="flex flex-col">
-                  <h1 className="text-base font-semibold text-[var(--color-black)] ">
-                    {selectedStation.place_name}
-                  </h1>
-                  <p className="text-xs text-gray-500">
-                    {selectedStation.road_address_name}
-                  </p>
-                </div>
-
-                <X
-                  className="w-6 h-6 text-[var(--color-black)] cursor-pointer"
-                  onClick={() => setSelectedStation(null)}
-                />
-              </div>
+    <div className="w-full flex flex-col items-center justify-center px-5">
+      <div className="w-full max-w-[700px] flex flex-col mx-auto">
+        {!selectedStation ? (
+          <>
+            <h1 className="text-base font-semibold py-8 text-[var(--color-black)] text-center">
+              출발할 위치를 입력해주세요
+            </h1>
+            <div className="flex flex-1 flex-col w-full">
+              <Input
+                icon={<Search className="w-4 h-4" onClick={searchHandler} />}
+                placeholder="출발지 검색"
+                value={query}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setQuery(e.target.value)
+                }
+                fullWidth={true}
+                onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+                  if (e.key === "Enter") searchHandler();
+                }}
+              />
+              <SubwaySearchResultList
+                results={results}
+                onSelect={selectHandler}
+                keyword={query}
+              />
+              {loading && <div className="text-center py-2">검색 중</div>}
             </div>
-          )}
-          <div className="mt-auto w-full gap-7">
-            <Button
-              state={selectedStation ? "default" : "disabled"}
-              className="w-full"
-            >
-              다음
-            </Button>
+          </>
+        ) : (
+          <div className="flex flex-1 flex-col w-full items-center py-7 justify-center gap-4">
+            <div className="flex w-full justify-between">
+              <div className="flex flex-col">
+                <h1 className="text-base font-semibold text-[var(--color-black)] ">
+                  {selectedStation.place_name}
+                </h1>
+                <p className="text-xs text-gray-500">
+                  {selectedStation.road_address_name}
+                </p>
+              </div>
+              <X
+                className="w-6 h-6 text-[var(--color-black)] cursor-pointer"
+                onClick={resetHandler}
+              />
+            </div>
           </div>
+        )}
+        <div className="w-full mt-8">
+          <Button
+            state={selectedStation ? "default" : "disabled"}
+            className="w-full"
+          >
+            다음
+          </Button>
         </div>
       </div>
-    </BottomSheet>
+    </div>
   );
 };
+
 export default SubwaySearch;

--- a/src/components/layout/GroupHeader.tsx
+++ b/src/components/layout/GroupHeader.tsx
@@ -47,7 +47,7 @@ const GroupHeader = ({
     <>
       {/* group 헤더,  그룹 정보 : 그룹명, 소개문구, 인원수*/}
       <div className="w-full bg-[color:var(--color-primary-400)] flex justify-center items-center min-w-[375px]">
-        <div className="flex flex-col w-full max-w-[740px]  items-center justify-center gap-4 pb-5 pt-10 sm:pt-18 px-5">
+        <div className="flex flex-col w-full max-w-[740px]  items-center justify-center gap-4 pb-5 pt-10 sm:pt-19 px-5">
           <div className="w-full flex justify-between items-center">
             <span onClick={handleBack} className="cursor-pointer">
               <ChevronLeft

--- a/src/components/ui/BottomSheet.tsx
+++ b/src/components/ui/BottomSheet.tsx
@@ -35,10 +35,6 @@ const BottomSheet = ({
   const sheetRef = useRef<SheetRef>(null);
   const snapTo = (i: number) => {
     if (typeof window === "undefined") return;
-
-    const isMobile = /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
-    if (!isMobile) return;
-
     sheetRef.current?.snapTo(i);
   };
 

--- a/src/components/ui/SubwaySearchResultList.tsx
+++ b/src/components/ui/SubwaySearchResultList.tsx
@@ -12,9 +12,10 @@ const SubwaySearchResultList: React.FC<SubwaySearchResultListProps> = ({
   onSelect,
   keyword,
 }) => {
+  const needScroll = results.length > 4;
   return (
     <div className="flex flex-col gap-3.5">
-      <div className="max-h-[274px] overflow-y-auto">
+      <div className={needScroll ? "max-h-[232px] overflow-y-auto" : ""}>
         {results.map((station) => (
           <SubwaySearchResultItem
             key={station.id}


### PR DESCRIPTION
## 📝 요약(Summary)

- 바텀 시트 프롭스 적용하여 변경
- 변경된 헤더 적용
- 그룹헤더 pt 1 수정
- 바텀 시트 안에 ui 수정

---

## 🛠️ PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📸스크린샷 (선택)

<img width="1184" height="1172" alt="image" src="https://github.com/user-attachments/assets/81621fe6-a76f-4ada-a7f2-2b5c0a12a8d2" />


---

## 💬 공유사항 to 리뷰어

 바텀 시트 한번만 봐주시오
