### PR TITLE
[Feat] 오프라인 일정 상세 정보 API 연결

### DIFF
--- a/src/app/utils/dateFormat.ts
+++ b/src/app/utils/dateFormat.ts
@@ -28,3 +28,37 @@ export const formatTime = (date: Date) => {
   const minutes = date.getMinutes();
   return `${hours}:${minutes}`;
 };
+
+/**
+ * 요일 반환
+ * @param date 날짜
+ * @returns 요일 (한글)
+ */
+const getKoreanDay = (date: Date) => {
+  const days = ["일", "월", "화", "수", "목", "금", "토"];
+  return days[date.getDay()];
+};
+
+/**
+ * 일정 시간 문자열로 변환
+ * @param startTime 시작 시간
+ * @param endTime 종료 시간
+ * @returns 예: 2025년 8월 9일 (금) 17:30 - 18:30
+ */
+
+export const formatSchedule = (startTime: string, endTime: string): string => {
+  const startDate = new Date(startTime);
+  const endDate = new Date(endTime);
+
+  const year = startDate.getFullYear();
+  const month = startDate.getMonth() + 1;
+  const day = startDate.getDate();
+  const dayOfWeek = getKoreanDay(startDate);
+
+  const startHour = String(startDate.getHours()).padStart(2, "0");
+  const startMinute = String(startDate.getMinutes()).padStart(2, "0");
+  const endHour = String(endDate.getHours()).padStart(2, "0");
+  const endMinute = String(endDate.getMinutes()).padStart(2, "0");
+
+  return `${year}년 ${month}월 ${day}일 (${dayOfWeek}) ${startHour}:${startMinute} - ${endHour}:${endMinute}`;
+};

--- a/src/components/feature/WorkSpace.tsx
+++ b/src/components/feature/WorkSpace.tsx
@@ -8,7 +8,7 @@ import canvaIcon from "@/assets/icon/canva_icon.svg";
 import Image from "next/image";
 import Link from "next/link";
 
-type Platform = "GITHUB" | "NOTION" | "FIGMA" | "GOOGLEDOCS" | "MIRO" | "CANVA";
+type Platform = "GITHUB" | "NOTION" | "FIGMA" | "GOOGLE_DOS" | "MIRO" | "CANVA";
 interface WorkSpaceProps {
   workspaces:
     | {
@@ -24,7 +24,7 @@ const WorkSpace = ({ scheduleId, workspaces }: WorkSpaceProps) => {
     GITHUB: githubIcon,
     NOTION: notionIcon,
     FIGMA: figmaIcon,
-    GOOGLEDOCS: googleDocsIcon,
+    GOOGLE_DOS: googleDocsIcon,
     MIRO: miroIcon,
     CANVA: canvaIcon,
   };

--- a/src/components/feature/schedule/detail/OfflineScheduleDetail.tsx
+++ b/src/components/feature/schedule/detail/OfflineScheduleDetail.tsx
@@ -1,39 +1,37 @@
 "use client";
-import { useParams } from "next/navigation";
+import {
+  ScheduleDetailType,
+  WorkspacePlatformType,
+  WorkspaceType,
+} from "@/types/schedule";
 import MeetingLocation from "../../MeetingLocation";
 import ScheduleDetailContent from "./ScheduleDetailContent";
 import ScheduleDetailLayout from "./ScheduleDetailLayout";
-import { useGroupSchedule, Workspace } from "@/lib/api/scheduleApi";
-import GlobalLoading from "@/app/loading";
 import { formatSchedule } from "@/app/utils/dateFormat";
 
-const OfflineScheduleDetail = () => {
-  const params = useParams();
-  const scheduleId = params.Id as string;
+interface OfflineScheduleDetailProps {
+  scheduleId: string;
+  data: ScheduleDetailType;
+}
 
-  const { data: scheduleData } = useGroupSchedule(scheduleId);
-
-  if (!scheduleData || !scheduleData.data) {
-    return <GlobalLoading />;
-  }
-
+const OfflineScheduleDetail = ({
+  scheduleId,
+  data,
+}: OfflineScheduleDetailProps) => {
   return (
     <ScheduleDetailLayout>
       <ScheduleDetailContent
         scheduleId={scheduleId}
-        members={scheduleData.data.members}
-        time={formatSchedule(
-          scheduleData.data.startTime,
-          scheduleData.data.endTime
-        )}
-        workspace={scheduleData.data.workspaces.map((workspace: Workspace) => ({
-          platform: workspace.type,
+        members={data.members}
+        time={formatSchedule(data.startTime, data.endTime)}
+        workspace={data.workspaces.map((workspace: WorkspaceType) => ({
+          platform: workspace.type as WorkspacePlatformType,
           name: workspace.name,
         }))}
       >
         <MeetingLocation
-          location={scheduleData.data.location}
-          specificLocation={scheduleData.data.specificLocation}
+          location={data.location}
+          specificLocation={data.specificLocation}
         />
       </ScheduleDetailContent>
     </ScheduleDetailLayout>

--- a/src/components/feature/schedule/detail/OfflineScheduleDetail.tsx
+++ b/src/components/feature/schedule/detail/OfflineScheduleDetail.tsx
@@ -1,23 +1,36 @@
+"use client";
+import { useParams } from "next/navigation";
 import MeetingLocation from "../../MeetingLocation";
 import ScheduleDetailContent from "./ScheduleDetailContent";
 import ScheduleDetailLayout from "./ScheduleDetailLayout";
+import { useGroupSchedule, Workspace } from "@/lib/api/scheduleApi";
+import GlobalLoading from "@/app/loading";
 
 const OfflineScheduleDetail = () => {
-  const scheduleId = "1";
+  const params = useParams();
+  const scheduleId = params.Id as string;
+
+  const { data: scheduleData } = useGroupSchedule(scheduleId);
+
+  if (!scheduleData || !scheduleData.data) {
+    return <GlobalLoading />;
+  }
 
   return (
     <ScheduleDetailLayout>
       <ScheduleDetailContent
         scheduleId={scheduleId}
-        members={["박준규", "카리나"]}
-        time="7월 5일 (금) 12:00 - 24:00"
-        workspace={[
-          { platform: "NOTION", name: "프론트엔드 기획서" },
-          { platform: "GITHUB", name: "이때 어때 레포지토리" },
-          { platform: "MIRO", name: "이때 어때 미로" },
-        ]}
+        members={scheduleData.data.members}
+        time={scheduleData.data.startTime}
+        workspace={scheduleData.data.workspaces.map((workspace: Workspace) => ({
+          platform: workspace.type,
+          name: workspace.name,
+        }))}
       >
-        <MeetingLocation location="강남역" specificLocation="강남역 스타벅스" />
+        <MeetingLocation
+          location={scheduleData.data.location}
+          specificLocation={scheduleData.data.specificLocation}
+        />
       </ScheduleDetailContent>
     </ScheduleDetailLayout>
   );

--- a/src/components/feature/schedule/detail/OfflineScheduleDetail.tsx
+++ b/src/components/feature/schedule/detail/OfflineScheduleDetail.tsx
@@ -5,6 +5,7 @@ import ScheduleDetailContent from "./ScheduleDetailContent";
 import ScheduleDetailLayout from "./ScheduleDetailLayout";
 import { useGroupSchedule, Workspace } from "@/lib/api/scheduleApi";
 import GlobalLoading from "@/app/loading";
+import { formatSchedule } from "@/app/utils/dateFormat";
 
 const OfflineScheduleDetail = () => {
   const params = useParams();
@@ -21,7 +22,10 @@ const OfflineScheduleDetail = () => {
       <ScheduleDetailContent
         scheduleId={scheduleId}
         members={scheduleData.data.members}
-        time={scheduleData.data.startTime}
+        time={formatSchedule(
+          scheduleData.data.startTime,
+          scheduleData.data.endTime
+        )}
         workspace={scheduleData.data.workspaces.map((workspace: Workspace) => ({
           platform: workspace.type,
           name: workspace.name,

--- a/src/components/feature/schedule/detail/OnlineScheduleDetail.tsx
+++ b/src/components/feature/schedule/detail/OnlineScheduleDetail.tsx
@@ -1,21 +1,32 @@
+import {
+  ScheduleDetailType,
+  WorkspacePlatformType,
+  WorkspaceType,
+} from "@/types/schedule";
 import OnlineMeetingRoom from "../../OnlineMeetingRoom";
 import ScheduleDetailContent from "./ScheduleDetailContent";
 import ScheduleDetailLayout from "./ScheduleDetailLayout";
+import { formatSchedule } from "@/app/utils/dateFormat";
 
-const OnlineScheduleDetail = () => {
-  const scheduleId = "1";
+interface OnineScheduleDetailProps {
+  scheduleId: string;
+  data: ScheduleDetailType;
+}
 
+const OnlineScheduleDetail = ({
+  scheduleId,
+  data,
+}: OnineScheduleDetailProps) => {
   return (
     <ScheduleDetailLayout>
       <ScheduleDetailContent
         scheduleId={scheduleId}
-        members={["박준규", "카리나"]}
-        time="7월 5일 (금) 12:00 - 24:00"
-        workspace={[
-          { platform: "NOTION", name: "프론트엔드 기획서" },
-          { platform: "GITHUB", name: "이때 어때 레포지토리" },
-          { platform: "MIRO", name: "이때 어때 미로" },
-        ]}
+        members={data.members}
+        time={formatSchedule(data.startTime, data.endTime)}
+        workspace={data.workspaces.map((workspace: WorkspaceType) => ({
+          platform: workspace.type as WorkspacePlatformType,
+          name: workspace.name,
+        }))}
       >
         <OnlineMeetingRoom platform="zoom" name=" 박준규 팬미팅" />
       </ScheduleDetailContent>

--- a/src/components/feature/schedule/detail/ScheduleDetail.tsx
+++ b/src/components/feature/schedule/detail/ScheduleDetail.tsx
@@ -1,10 +1,41 @@
+import { useParams } from "next/navigation";
 import OfflineScheduleDetail from "./OfflineScheduleDetail";
 import OnlineScheduleDetail from "./OnlineScheduleDetail";
+import { useGroupSchedule } from "@/lib/api/scheduleApi";
+import GlobalLoading from "@/app/loading";
+import { useEffect, useState } from "react";
 
 const ScheduleDetail = () => {
-  const isOnline = true;
+  const params = useParams();
+  const scheduleId = params.Id as string;
+  const [isOnline, setIsOnline] = useState<boolean | null>(null);
+
+  const { data: scheduleData } = useGroupSchedule(scheduleId);
+
+  useEffect(() => {
+    if (scheduleData?.data.meetingType) {
+      setIsOnline(scheduleData.data.meetingType !== "OFFLINE");
+    }
+  }, [scheduleData]);
+
+  if (!scheduleData || !scheduleData.data || isOnline === null) {
+    return <GlobalLoading />;
+  }
+
   return (
-    <>{!isOnline ? <OnlineScheduleDetail /> : <OfflineScheduleDetail />}</>
+    <>
+      {isOnline ? (
+        <OnlineScheduleDetail
+          scheduleId={scheduleId}
+          data={scheduleData.data}
+        />
+      ) : (
+        <OfflineScheduleDetail
+          scheduleId={scheduleId}
+          data={scheduleData.data}
+        />
+      )}
+    </>
   );
 };
 export default ScheduleDetail;

--- a/src/components/feature/schedule/detail/ScheduleDetail.tsx
+++ b/src/components/feature/schedule/detail/ScheduleDetail.tsx
@@ -3,28 +3,20 @@ import OfflineScheduleDetail from "./OfflineScheduleDetail";
 import OnlineScheduleDetail from "./OnlineScheduleDetail";
 import { useGroupSchedule } from "@/lib/api/scheduleApi";
 import GlobalLoading from "@/app/loading";
-import { useEffect, useState } from "react";
 
 const ScheduleDetail = () => {
   const params = useParams();
-  const scheduleId = params.Id as string;
-  const [isOnline, setIsOnline] = useState<boolean | null>(null);
+  const scheduleId = params.id as string;
 
-  const { data: scheduleData } = useGroupSchedule(scheduleId);
+  const { data: scheduleData, isPending } = useGroupSchedule(scheduleId);
 
-  useEffect(() => {
-    if (scheduleData?.data.meetingType) {
-      setIsOnline(scheduleData.data.meetingType !== "OFFLINE");
-    }
-  }, [scheduleData]);
-
-  if (!scheduleData || !scheduleData.data || isOnline === null) {
+  if (isPending) {
     return <GlobalLoading />;
   }
 
   return (
     <>
-      {isOnline ? (
+      {scheduleData.data.meetingType === "ONLINE" ? (
         <OnlineScheduleDetail
           scheduleId={scheduleId}
           data={scheduleData.data}

--- a/src/components/feature/schedule/detail/ScheduleDetail.tsx
+++ b/src/components/feature/schedule/detail/ScheduleDetail.tsx
@@ -3,6 +3,8 @@ import OnlineScheduleDetail from "./OnlineScheduleDetail";
 
 const ScheduleDetail = () => {
   const isOnline = true;
-  return <>{isOnline ? <OnlineScheduleDetail /> : <OfflineScheduleDetail />}</>;
+  return (
+    <>{!isOnline ? <OnlineScheduleDetail /> : <OfflineScheduleDetail />}</>
+  );
 };
 export default ScheduleDetail;

--- a/src/components/feature/schedule/detail/ScheduleDetailContent.tsx
+++ b/src/components/feature/schedule/detail/ScheduleDetailContent.tsx
@@ -3,14 +3,7 @@ import MeetingInfo from "../../MeetingInfo";
 import WorkSpace from "../../WorkSpace";
 import KakaoScript from "../../KakaoScript";
 import { useKakaoShare } from "@/lib/api/useKakaoShare";
-
-type WorkSpaceType =
-  | "NOTION"
-  | "GITHUB"
-  | "MIRO"
-  | "FIGMA"
-  | "GOOGLEDOCS"
-  | "CANVA";
+import { WorkSpaceType } from "@/lib/api/scheduleApi";
 
 interface ScheduleDetailContentProps {
   scheduleId: string;

--- a/src/components/feature/schedule/detail/ScheduleDetailContent.tsx
+++ b/src/components/feature/schedule/detail/ScheduleDetailContent.tsx
@@ -3,13 +3,13 @@ import MeetingInfo from "../../MeetingInfo";
 import WorkSpace from "../../WorkSpace";
 import KakaoScript from "../../KakaoScript";
 import { useKakaoShare } from "@/lib/api/useKakaoShare";
-import { WorkSpaceType } from "@/lib/api/scheduleApi";
+import { WorkspacePlatformType } from "@/types/schedule";
 
 interface ScheduleDetailContentProps {
   scheduleId: string;
   members: string[];
   time: string;
-  workspace: { platform: WorkSpaceType; name: string }[];
+  workspace: { platform: WorkspacePlatformType; name: string }[];
   children: React.ReactNode;
 }
 

--- a/src/components/feature/schedule/edit/workspace/EditWorkspace.tsx
+++ b/src/components/feature/schedule/edit/workspace/EditWorkspace.tsx
@@ -5,7 +5,6 @@ const EditWorkspace = ({
 }: {
   onEditClick: (data: { type: string; name: string; url: string }) => void;
 }) => {
-  
   return (
     <>
       <div className="space-y-4">
@@ -34,7 +33,7 @@ const EditWorkspace = ({
           onClick={onEditClick}
         />
         <WorkspaceItem
-          type="googledocs"
+          type="google_dos"
           name="이때어때 구글 독스"
           url="https://www.notion.so/Team07-21e15a01205480a49fc6d1e73f119a19"
           onClick={onEditClick}

--- a/src/components/feature/schedule/edit/workspace/WorkspaceBottomSheet.tsx
+++ b/src/components/feature/schedule/edit/workspace/WorkspaceBottomSheet.tsx
@@ -22,14 +22,14 @@ const workspaceLogos = {
   MIRO: miroIcon,
   FIGMA: figmaIcon,
   CANVA: canvaIcon,
-  GOOGLEDOCS: googledocsIcon,
+  GOOGLE_DOS: googledocsIcon,
 } as const;
 
 const workspaceTypes = [
   "GITHUB",
   "NOTION",
   "FIGMA",
-  "GOOGLEDOCS",
+  "GOOGLE_DOS",
   "CANVA",
   "MIRO",
 ] as const;

--- a/src/components/feature/schedule/edit/workspace/WorkspaceItem.tsx
+++ b/src/components/feature/schedule/edit/workspace/WorkspaceItem.tsx
@@ -8,7 +8,7 @@ import Image from "next/image";
 import { Edit } from "lucide-react";
 
 interface WorkspaceItemProps {
-  type: "github" | "notion" | "miro" | "figma" | "canva" | "googledocs";
+  type: "github" | "notion" | "miro" | "figma" | "canva" | "google_dos";
   name: string;
   url: string;
   onClick?: (data: { type: string; name: string; url: string }) => void;
@@ -20,7 +20,7 @@ const workspaceLogos = {
   miro: miroIcon,
   figma: figmaIcon,
   canva: canvaIcon,
-  googledocs: googledocsIcon,
+  google_dos: googledocsIcon,
 };
 
 const WorkspaceItem = ({ type, name, url, onClick }: WorkspaceItemProps) => {

--- a/src/lib/api/scheduleApi.ts
+++ b/src/lib/api/scheduleApi.ts
@@ -1,22 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { axiosInstance } from "./axiosInstance";
-
-export interface Workspace {
-  type: string;
-  name: string;
-  url: string;
-}
-
-export type WorkSpaceType =
-  | "GITHUB"
-  | "NOTION"
-  | "FIGMA"
-  | "GOOGLE_DOS"
-  | "MIRO"
-  | "CANVA";
+import { ScheduleType, WorkspacePlatformType } from "@/types/schedule";
 
 interface CreateWorkSpaceRequest {
-  workspace: WorkSpaceType;
+  workspace: WorkspacePlatformType;
   workspaceName: string;
   url: string;
 }

--- a/src/lib/api/scheduleApi.ts
+++ b/src/lib/api/scheduleApi.ts
@@ -1,6 +1,12 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { axiosInstance } from "./axiosInstance";
 
+export interface Workspace {
+  type: string;
+  name: string;
+  url: string;
+}
+
 export type WorkSpaceType =
   | "GITHUB"
   | "NOTION"

--- a/src/lib/api/scheduleApi.ts
+++ b/src/lib/api/scheduleApi.ts
@@ -11,7 +11,7 @@ export type WorkSpaceType =
   | "GITHUB"
   | "NOTION"
   | "FIGMA"
-  | "GOOGLEDOCS"
+  | "GOOGLE_DOS"
   | "MIRO"
   | "CANVA";
 

--- a/src/types/schedule.d.ts
+++ b/src/types/schedule.d.ts
@@ -11,6 +11,36 @@ interface ScheduleType {
   }[];
 }
 
+export interface ScheduleDetailType {
+  eventId: number;
+  startTime: string;
+  endTime: string;
+  location: string;
+  specificLocation: string;
+  scheduleName: string;
+  description: string;
+  meetingType: string;
+  meetingPlatform: string;
+  platformName: string;
+  platformUrl: string;
+  members: string[];
+  workspaces: WorkspaceType[];
+}
+
+export type WorkspacePlatformType =
+  | "GITHUB"
+  | "NOTION"
+  | "FIGMA"
+  | "GOOGLE_DOS"
+  | "MIRO"
+  | "CANVA";
+
+export interface WorkspaceType {
+  type: string;
+  name: string;
+  url: string;
+}
+
 interface EventInfoType {
   title: string;
   eventId: number;


### PR DESCRIPTION
## #️⃣ Issue Number

<!-- 관련된 이슈 번호를 작성해주세요. 예: #12, #34 없다면 무시 -->

---

## 📝 요약(Summary)

- 오프라인 일정 상세 페이지 API 연결 완료

- dateFormat.ts 파일에 아래 데이터를 `2025년 8월 9일 (토) 17:30 - 23:00` 과 같은 형식으로 변환해주는 함수 추가
`"startTime": "2025-08-09T17:30:00",
  "endTime": "2025-08-09T23:00:00"` 
`formatSchedule(startTime, endTime)`



---

## 🛠️ PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📸스크린샷 (선택)
<img width="648" height="1035" alt="Screenshot 2025-07-17 at 12 02 44 AM" src="https://github.com/user-attachments/assets/3f90bf9d-9d90-4a98-ace1-004b91468404" />

---

## 💬 공유사항 to 리뷰어

- TODO 
     - 헤더에 해당 스케줄에 대한 정보 전달 필요
     - 방장/일반 멤버 분기 처리
     - 만남장소가 정해진 경우 배경 지도 렌더링 작업
- 서버에서 구글 독스 타입 이름을 GOOGLE_DOS 로 저장되어 있어 프론트 코드도 동일하게 수정하였습니다. 백엔드에서 오타 수정해주면 다시 수정할예정입니다.
