### PR TITLE
[Feat] 그룹 생성/수정 관련 API 리팩토링 및 UI 애니메이션 개선

### DIFF
--- a/src/app/group/[groupId]/schedule/create/select/page.tsx
+++ b/src/app/group/[groupId]/schedule/create/select/page.tsx
@@ -10,6 +10,11 @@ import HeaderTop from "@/components/layout/HeaderTop";
 import { useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Header from "@/components/layout/Header";
+import { motion } from "framer-motion";
+import {
+  itemVariants,
+  listVariants,
+} from "@/components/feature/schedule/motion";
 
 const GroupScheduleCreateSelectPage = () => {
   const [selected, setSelected] = useState("create");
@@ -34,11 +39,16 @@ const GroupScheduleCreateSelectPage = () => {
       <div className="w-full">
         <div className="min-w-[375px] w-full max-w-185 px-5 flex flex-col items-center gap-9 mx-auto pt-25 sm:pt-40">
           <HeaderTop />
-          <div className="flex flex-col w-full gap-8">
+          <motion.div
+            variants={listVariants}
+            initial="hidden"
+            animate="visible"
+            className="flex flex-col w-full gap-8"
+          >
             <p className="w-full text-xl font-bold text-[color:var(--color-black)] text-start">
               일정 추가 방법을 선택해주세요
             </p>
-            <div className="w-full flex gap-5">
+            <motion.div className="w-full flex gap-5" variants={itemVariants}>
               <div className="w-full" onClick={() => setSelected("create")}>
                 <OptionBox isSelected={selected === "create"}>
                   <Image
@@ -67,13 +77,31 @@ const GroupScheduleCreateSelectPage = () => {
                   </p>
                 </OptionBox>
               </div>
-            </div>
-          </div>
-          {selected === "create" ? (
-            <Tip>새로운 만남, 여기서부터 시작해요! 🗓️</Tip>
-          ) : (
-            <Tip>전에 만든 일정이 있다면 불러와서 바로 써보세요! 🙌</Tip>
-          )}
+            </motion.div>
+            <motion.div className="w-full" variants={itemVariants}>
+              {selected === "create" ? (
+                <motion.div
+                  key="create"
+                  variants={itemVariants}
+                  initial="hidden"
+                  animate="visible"
+                  exit="hidden"
+                >
+                  <Tip>새로운 만남, 여기서부터 시작해요! 🗓️</Tip>
+                </motion.div>
+              ) : (
+                <motion.div
+                  key="load"
+                  variants={itemVariants}
+                  initial="hidden"
+                  animate="visible"
+                  exit="hidden"
+                >
+                  <Tip>전에 만든 일정이 있다면 불러와서 바로 써보세요! 🙌</Tip>
+                </motion.div>
+              )}
+            </motion.div>
+          </motion.div>
 
           <div className="fixed w-full left-0 right-0 px-5 bottom-9">
             <div className="max-w-185 mx-auto">

--- a/src/app/group/create/page.tsx
+++ b/src/app/group/create/page.tsx
@@ -3,26 +3,35 @@ import Header from "@/components/layout/Header";
 import HeaderTop from "@/components/layout/HeaderTop";
 import { Button } from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
-import { useCreateGroup } from "@/lib/api/groupApi";
+import { createGroup } from "@/lib/api/groupApi";
+import { useRouter } from "next/navigation";
 import { ChangeEvent, useState } from "react";
 
 const CreateGroup = () => {
+  const router = useRouter();
   const [groupName, setGroupName] = useState("");
-  const [groupDescription, setGroupDescription] = useState("");
+  const [description, setDescription] = useState("");
 
-  const createGroupMutation = useCreateGroup();
-
-  const handleCreateGroup = () => {
-    createGroupMutation.mutate({
-      groupName: groupName.trim(),
-      description: groupDescription.trim(),
-    });
+  const handleCreateGroup = async () => {
+    try {
+      const response = await createGroup({ groupName, description });
+      if (response.code === "200") {
+        if (response.data.groupId) {
+          router.push(`/group/${response.data.groupId}`);
+        } else {
+          throw new Error(response.message);
+        }
+      } else {
+        throw new Error(response.message);
+      }
+    } catch (err) {
+      console.error(err);
+    }
   };
 
   const isFormValid =
-    groupName.trim().length > 0 && groupDescription.trim().length > 0;
-  const isLoading = createGroupMutation.isPending;
-  const buttonState = !isFormValid || isLoading ? "disabled" : "default";
+    groupName.trim().length > 0 && description.trim().length > 0;
+  const buttonState = !isFormValid ? "disabled" : "default";
 
   return (
     <div className="bg-[color:var(--color-white)] min-h-screen">
@@ -49,9 +58,9 @@ const CreateGroup = () => {
             label="그룹 설명"
             placeholder="그룹 설명을 입력하세요"
             maxLength={50}
-            value={groupDescription}
+            value={description}
             onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
-              setGroupDescription(e.target.value)
+              setDescription(e.target.value)
             }
             fullWidth={true}
             isTextarea
@@ -60,7 +69,7 @@ const CreateGroup = () => {
         <div className="fixed w-full left-0 right-0 px-5 bottom-9">
           <div className="max-w-185 mx-auto">
             <Button onClick={handleCreateGroup} state={buttonState}>
-              {isLoading ? "생성 중.." : "그룹 생성"}
+              그룹 생성
             </Button>
           </div>
         </div>

--- a/src/components/feature/meeting/MeetingTypeChoice.tsx
+++ b/src/components/feature/meeting/MeetingTypeChoice.tsx
@@ -6,6 +6,11 @@ import HeaderTop from "@/components/layout/HeaderTop";
 import Header from "@/components/layout/Header";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { motion } from "framer-motion";
+import {
+  itemVariants,
+  listVariants,
+} from "@/components/feature/schedule/motion";
 
 const MeetingTypeChoice = () => {
   const router = useRouter();
@@ -30,15 +35,50 @@ const MeetingTypeChoice = () => {
         <div className="flex flex-col  max-h-screen relative max-w-[740px] mx-auto px-5">
           <main className="flex flex-col gap-8 relative pt-25 sm:pt-40 min-h-screen box-border">
             <h1 className="text-xl font-bold">모임 유형을 선택해주세요</h1>
-            <MeetingTypeOptions
-              selectedType={selectedType}
-              setSelectedType={setSelectedType}
-            />
-            <Tip>
-              한번 모임은 그날 딱 한 번 만날 때 좋아요.
-              <br />
-              자주 모임은 그룹 안에서 소모임을 꾸리고 여러번 만날 수 있어요.
-            </Tip>
+            <motion.div
+              variants={listVariants}
+              initial="hidden"
+              animate="visible"
+              className="space-y-8"
+            >
+              <motion.div className="w-full" variants={itemVariants}>
+                <MeetingTypeOptions
+                  selectedType={selectedType}
+                  setSelectedType={setSelectedType}
+                />
+              </motion.div>
+              <motion.div className="w-full" variants={itemVariants}>
+                {selectedType === "once" ? (
+                  <motion.div
+                    key="once"
+                    variants={itemVariants}
+                    initial="hidden"
+                    animate="visible"
+                    exit="hidden"
+                  >
+                    <Tip>
+                      한 번 모임은 정해진 날 딱 한 번 만나는 일정이에요! 🎉
+                      <br />
+                      친구들과 번개 모임이나 영화 보기, 특별한 날에 좋아요 🌳
+                    </Tip>
+                  </motion.div>
+                ) : (
+                  <motion.div
+                    key="recurring"
+                    variants={itemVariants}
+                    initial="hidden"
+                    animate="visible"
+                    exit="hidden"
+                  >
+                    <Tip>
+                      자주 모임은 그룹을 만들어 여러 번 만날 수 있어요! 🔁
+                      <br />
+                      독서모임, 스터디, 운동모임처럼 꾸준한 만남에 딱이에요 📚🏃‍♀️
+                    </Tip>
+                  </motion.div>
+                )}
+              </motion.div>
+            </motion.div>
             <div className="w-full flex items-center justify-center absolute bottom-9 left-0">
               <Button state="default" onClick={handleNext}>
                 다음

--- a/src/lib/api/groupApi.ts
+++ b/src/lib/api/groupApi.ts
@@ -4,23 +4,6 @@ import { useRouter } from "next/navigation";
 import Toast from "@/components/ui/Toast";
 import toast from "react-hot-toast";
 
-export interface CreateGroupRequest {
-  groupName: string;
-  description: string;
-}
-
-export interface UpdateGroupRequest {
-  groupName: string;
-  description: string;
-}
-
-export interface GroupResponse {
-  code: string;
-  message: string;
-  data: null;
-  id: string;
-}
-
 export interface UpdateMemberPermissionsReqeust {
   groupId: string;
   userId: string;
@@ -38,33 +21,61 @@ const getGroups = async () => {
   return res.data;
 };
 
-// 특정 그룹 정보 조회
-const getGroup = async (id: string) => {
-  const res = await axiosInstance.get(`/groups`, { params: { id } });
+/**
+ * 그룹 정보 조회
+ * @param groupId 그룹 이름
+ * @returns
+ */
+export const getGroup = async (groupId: string) => {
+  const res = await axiosInstance.get(`/groups/schedule-groups/${groupId}`);
   return res.data;
 };
 
+/**
+ * 그룹 생성
+ * @param groupName 그룹 이름
+ * @param description 그룹 설명
+ * @returns
+ */
+export const createGroup = async (groupInfo: GroupInfoType) => {
+  const response = await axiosInstance.post("/groups/create", groupInfo);
+  return response.data;
+};
+
+/**
+ * 그룹 정보 수정
+ * @param groupId 그룹 ID
+ * @param groupName 그룹 이름
+ * @param description 그룹 설명
+ * @returns
+ */
+export const updateGroup = async (groupId: string, data: GroupInfoType) => {
+  const response = await axiosInstance.patch(`/groups/${groupId}`, data);
+  return response.data;
+};
+
+/**
+ * 그룹 삭제
+ * @param groupId 그룹 ID
+ * @returns
+ */
+export const deleteGroup = async (groupId: string) => {
+  const res = await axiosInstance.delete(`/groups/${groupId}`, { data: {} });
+  return res.data;
+};
+
+/**
+ * 일회성 일정으로 그룹 일정으로 편입
+ * @param scheduleId 스케줄 ID
+ * @param groupId 그룹 ID
+ * @returns
+ */
 export const moveSchedule = async (scheduleId: number, groupId: number) => {
   const response = await axiosInstance.patch(`/groups/move-schedule`, {
     groupId,
     scheduleId,
   });
   return response.data;
-};
-
-const createGroup = async (data: CreateGroupRequest) => {
-  const res = await axiosInstance.post("/groups/create", data);
-  return res.data;
-};
-
-const updateGroup = async (id: string, data: UpdateGroupRequest) => {
-  const res = await axiosInstance.patch(`/groups/${id}`, data);
-  return res.data;
-};
-
-const deleteGroup = async (id: string) => {
-  const res = await axiosInstance.delete(`/groups/${id}`, { data: {} });
-  return res.data;
 };
 
 const getGroupSchedules = async (groupId: string) => {
@@ -185,78 +196,11 @@ export const useGroupMembers = (groupId: string) => {
   });
 };
 
-export const useGroup = (id: string) => {
-  return useQuery({
-    queryKey: ["group", id],
-    queryFn: () => getGroup(id),
-    enabled: !!id,
-    retry: false,
-    refetchOnWindowFocus: false,
-  });
-};
-
 export const useGroups = () => {
   return useQuery({
     queryKey: ["groups"],
     queryFn: getGroups,
     retry: false,
     refetchOnWindowFocus: false,
-  });
-};
-
-export const useCreateGroup = () => {
-  const router = useRouter();
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: createGroup,
-    onSuccess: (data) => {
-      console.log("그룹 생성 성공 : ", data);
-      queryClient.invalidateQueries({ queryKey: ["groups"] });
-      //router.push(`/group/${data.id}`);
-      router.push(`/group/10001`);
-    },
-    onError: (err) => {
-      console.error("그룹 생성 실패 : ", err);
-    },
-  });
-};
-
-export const useUpdateGroup = () => {
-  const router = useRouter();
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: ({ id, data }: { id: string; data: UpdateGroupRequest }) =>
-      updateGroup(id, data),
-    onSuccess: (data) => {
-      console.log("그룹 정보 수정 성공 : ", data);
-      queryClient.invalidateQueries({ queryKey: ["groups"] });
-      queryClient.invalidateQueries({ queryKey: ["group", data.id] });
-
-      //router.push(`/group/${data.id}`);
-      router.push(`/group/10001`);
-    },
-    onError: (err) => {
-      console.error("그룹 정보 수정 실패 : ", err);
-    },
-  });
-};
-
-export const useDeleteGroup = () => {
-  const router = useRouter();
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (id: string) => deleteGroup(id),
-    onSuccess: (data) => {
-      console.log("그룹 삭제 성공 : ", data);
-      queryClient.invalidateQueries({ queryKey: ["groups"] });
-      //router.push(`/group/${data.id}`);
-      router.push(`/`);
-    },
-    onError: (err) => {
-      console.error("그룹 삭제 실패 : ", err);
-    },
   });
 };

--- a/src/types/group.d.ts
+++ b/src/types/group.d.ts
@@ -1,0 +1,4 @@
+interface GroupInfoType {
+  groupName: string;
+  description: string;
+}


### PR DESCRIPTION
## #️⃣ Issue Number

<!-- 관련된 이슈 번호를 작성해주세요. 예: #12, #34 없다면 무시 -->

---

## 📝 요약(Summary)

- 그룹 생성/수정/삭제 기능 mutation → `async/await` 방식으로 리팩토링
- 모임 유형 선택 페이지/일정 생성 방식 선택 페이지에 motion 적용
- 그룹 정보 (그룹 이름, 설명) 타입 정의 분리 -> `group.d.ts`

---

## 🛠️ PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📸스크린샷 (선택)

https://github.com/user-attachments/assets/4c694dfa-e62e-4328-aa2f-c63c3b17c55d


---

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
