### PR TITLE
[Fix] mypage - 에러 발생 시 사용자에게 알림 추가 및 로그아웃 후 리다이렉트 경로 수정

### DIFF
--- a/src/lib/api/authApi.ts
+++ b/src/lib/api/authApi.ts
@@ -24,6 +24,7 @@ export const useUpdateName = () => {
     },
     onError: (err) => {
       console.error("이름 변경 실패: ", err);
+      Toast("이름 수정 실패");
     },
   });
 };
@@ -34,6 +35,10 @@ export const useUpdateProfileImg = () => {
     mutationFn: () => axiosInstance.patch("/member/profile"),
     onSuccess: () => {
       ToastWell("🎉", "프로필 랜덤 수정 완료!");
+    },
+    onError: (err) => {
+      console.error("프로필 이미지 수정 실패", err);
+      Toast("프로필 랜덤 수정 실패");
     },
   });
 };
@@ -102,6 +107,7 @@ export const useUpdateFavoriteLocation = () => {
     },
     onError: (err) => {
       console.error("주변역 등록 실패", err);
+      Toast("주변역 수정 실패");
     },
   });
 };
@@ -112,11 +118,12 @@ export const useLogoutMutation = () => {
   return useMutation({
     mutationFn: logout,
     onSuccess: () => {
-      ToastWell("👻", "로그아웃되었습니다!");
-      router.push("/");
+      ToastWell("😇", "로그아웃되었습니다!");
+      router.push("/auth/login");
     },
     onError: (err) => {
       console.error("로그아웃 실패", err);
+      Toast("로그아웃 실패");
     },
   });
 };
@@ -127,12 +134,13 @@ export const useDeactiveMutation = () => {
   return useMutation({
     mutationFn: () => axiosInstance.delete("/member/withdraw"),
     onSuccess: () => {
-      ToastWell("👻", "탈퇴되었습니다!");
+      ToastWell("😇", "탈퇴되었습니다!");
 
-      router.push("/");
+      router.push("/auth/login");
     },
     onError: (err) => {
       console.error("탈퇴 실패", err);
+      Toast("탈퇴 실패");
     },
   });
 };


### PR DESCRIPTION
## #️⃣ Issue Number

<!-- 관련된 이슈 번호를 작성해주세요. 예: #12, #34 없다면 무시 -->

---

## 📝 요약(Summary)
- 로그아웃 후 랜딩페이지로 가던 경로를 로기인 페이지로 경로 수정
- 토스트 메시지 아이콘 수정 (윈도우, 맥 호환)
<!-- 이 PR에서 어떤 작업을 했는지 한두 줄로 요약해주세요 -->]
---

## 🛠️ PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📸스크린샷 (선택)

---

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
