### PR TITLE
Fix: GroupHeader handleBack에서 pathname과 커리 마라미터에 따른 분기 처리 추가

### DIFF
--- a/src/components/feature/group/CreateGroupPage.tsx
+++ b/src/components/feature/group/CreateGroupPage.tsx
@@ -22,7 +22,7 @@ const CreateGroupPage = () => {
       const response = await createGroup({ groupName, description });
       if (response.code === "200") {
         if (response.data.groupId) {
-          router.push(`/group/${response.data.groupId}/complete`);
+          router.replace(`/group/${response.data.groupId}/complete`);
         } else {
           throw new Error(response.message);
         }

--- a/src/components/feature/group/GroupCreatedPage.tsx
+++ b/src/components/feature/group/GroupCreatedPage.tsx
@@ -54,7 +54,7 @@ const GroupCreatedPage = () => {
         </motion.div>
         <div className="fixed w-full left-0 right-0 px-5 bottom-9">
           <div className="max-w-185 mx-auto">
-            <Button onClick={() => router.push(`/group/${groupId}`)}>
+            <Button onClick={() => router.replace(`/group/${groupId}`)}>
               그룹 페이지로 이동
             </Button>
           </div>

--- a/src/components/feature/meeting/TimeResult.tsx
+++ b/src/components/feature/meeting/TimeResult.tsx
@@ -82,7 +82,7 @@ const TimeResult = () => {
     try {
       const res = await createSchedule(payload);
       console.log(res);
-      router.push(`/schedule/${res.data.scheduleId}`);
+      router.push(`/schedule/${res.data.scheduleId}?created=true`);
     } catch (error) {
       console.error(error);
     }

--- a/src/components/layout/hooks/useGroupHeaderAction.ts
+++ b/src/components/layout/hooks/useGroupHeaderAction.ts
@@ -1,4 +1,4 @@
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useState } from "react";
 import { useLeaveGroup } from "@/lib/api/groupApi";
 import { useDeleteSchedule } from "@/lib/api/scheduleApi";
@@ -17,11 +17,16 @@ export const useGroupHeaderActions = ({
   const [isOpen, setIsOpen] = useState(false);
   const [isAlertOpen, setIsAlertOpen] = useState(false);
   const router = useRouter();
+  const pathname = usePathname();
   const leaveGroup = useLeaveGroup();
   const deleteSchedule = useDeleteSchedule();
 
   const handleBack = () => {
-    router.back();
+    if (pathname === `/group/${id}`) {
+      router.push("/");
+    } else {
+      router.back();
+    }
   };
 
   const clickEllipsisHandler = () => {

--- a/src/components/layout/hooks/useGroupHeaderAction.ts
+++ b/src/components/layout/hooks/useGroupHeaderAction.ts
@@ -1,4 +1,4 @@
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { useLeaveGroup } from "@/lib/api/groupApi";
 import { useDeleteSchedule } from "@/lib/api/scheduleApi";
@@ -18,11 +18,15 @@ export const useGroupHeaderActions = ({
   const [isAlertOpen, setIsAlertOpen] = useState(false);
   const router = useRouter();
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const leaveGroup = useLeaveGroup();
   const deleteSchedule = useDeleteSchedule();
 
   const handleBack = () => {
+    const created = searchParams.get("created");
     if (pathname === `/group/${id}`) {
+      router.push("/");
+    } else if (pathname === `/schedule/${id}` && created === "true") {
       router.push("/");
     } else {
       router.back();

--- a/src/lib/api/groupApi.ts
+++ b/src/lib/api/groupApi.ts
@@ -183,6 +183,7 @@ export const useLeaveGroup = () => {
     onSuccess: () => {
       ToastWell("✅", "그룹에서 나갔습니다");
       queryClient.invalidateQueries({ queryKey: ["user", "groupSchedule"] });
+      queryClient.invalidateQueries({ queryKey: ["dashboard", "groups"] });
       router.push(`/`);
     },
     onError: (err) => {


### PR DESCRIPTION
## #️⃣ Issue Number

<!-- 관련된 이슈 번호를 작성해주세요. 예: #12, #34 없다면 무시 -->

---

## 📝 요약(Summary)

<!-- 이 PR에서 어떤 작업을 했는지 한두 줄로 요약해주세요 -->


useGroupHeaderActions 훅 내에서 handleBack 로직 변경
- /group/:id에서 뒤로가기 시 → 홈(/)으로 이동
- /schedule/:id?created=true에서 뒤로가기 시 → 홈(/)으로 이동
- 그 외에는 기본 router.back() 사용

결과 조율 페이지에서 일정을 확정 지은 후 일정 페이지로 넘어 갈 시 쿼리 스트링에 created=true 값을 저장
> useSearchParams를 통해 created 쿼리 파라미터를 확인하고, pathname과 함께 조건 분기 처리

---

## 🛠️ PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📸스크린샷 (선택)

---

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
