### PR TITLE
🐛 [Fix] 대시보드 구글 스케줄 아이템 링크 이동 막기

### DIFF
--- a/src/components/dashboard/MyScheduleSection.tsx
+++ b/src/components/dashboard/MyScheduleSection.tsx
@@ -40,11 +40,17 @@ export const MyScheduleSection = ({
           </Link>
         </div>
         {filteredSchedules.length > 0 ? (
-          filteredSchedules.map((schedule) => (
-            <Link href={`/schedule/${schedule.id}`} key={schedule.id}>
-              <MyScheduleItem schedule={schedule} />
-            </Link>
-          ))
+          filteredSchedules.map((schedule) => {
+            if (schedule.source === "SERVICE") {
+              return (
+                <Link href={`/schedule/${schedule.id}`} key={schedule.id}>
+                  <MyScheduleItem schedule={schedule} />
+                </Link>
+              );
+            } else {
+              return <MyScheduleItem key={schedule.id} schedule={schedule} />;
+            }
+          })
         ) : (
           <div className="flex flex-1 justify-center items-center py-4">
             <EmptySchedule />


### PR DESCRIPTION
## #️⃣ Issue Number

<!-- 관련된 이슈 번호를 작성해주세요. 예: #12, #34 없다면 무시 -->

---

## 📝 요약(Summary)

- 대시보드에서 구글 일정 아이템 클릭 시 https://www.ittaeok.com/schedule/null 로 이동하는 문제 해결

---

## 🛠️ PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📸스크린샷 (선택)

---

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
