### PR TITLE
[Fix] 이벤트 생성 인원수 제한 및 초대 로직 수정

### DIFF
--- a/src/app/meeting/[eventId]/coordinate/[groupId]/page.tsx
+++ b/src/app/meeting/[eventId]/coordinate/[groupId]/page.tsx
@@ -15,17 +15,24 @@ const InvitePage = () => {
   const router = useRouter();
 
   const setInviteEventMember = async () => {
-    try {
-      if (group === "true") {
+    if (group === "true") {
+      try {
         await addGroupMember(groupId as string);
         ToastWell("🎉", "일정 조율을 위해 그룹에 참여했습니다!");
+      } catch (error) {
+        if (error instanceof AxiosError) {
+          Toast(error.response?.data.message);
+        } else {
+          Toast("알 수 없는 오류가 발생했습니다.");
+        }
       }
+    }
 
+    try {
       await setInviteEvent(Number(eventId), Number(groupId));
       ToastWell("🎉", "일정 초대가 완료되었어요!");
       router.push(`/meeting/${eventId}/coordinate`);
     } catch (error) {
-      console.error(error);
       if (error instanceof AxiosError) {
         if (error.status === 401) {
           localStorage.setItem("redirect", `${window.location.pathname}`);

--- a/src/components/feature/schedule/ScheduleModeList.tsx
+++ b/src/components/feature/schedule/ScheduleModeList.tsx
@@ -42,14 +42,13 @@ const ScheduleModeList = ({
                 value={schedule.maxMember}
                 placeholder="0"
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                  if (Number(e.target.value) >= 100) return;
+
                   setSchedule({
                     ...schedule,
                     maxMember: Number(e.target.value),
                   });
                 }}
-                inputMode="numeric"
-                pattern="[0-9]*"
-                min={1}
               />
             </div>
             <span> 명</span>


### PR DESCRIPTION
## #️⃣ Issue Number

<!-- 관련된 이슈 번호를 작성해주세요. 예: #12, #34 없다면 무시 -->

---

## 📝 요약(Summary)

### 이벤트 생성 인원수 제한
무한정으로 인원수입력이 가능하여 100명까지 인원 수 제한

### 초대 로직 수정
그룹 일정일경우 그룹 가입을 먼저 하는데 try 문의 초기에 진행하게 됨
근데 해당 인원이 그룹원이라면 이벤트 초대 로직 전에 catch 로 걸러져서 이벤트 가입 안되는 경우가 생기므로
로직 수정

---

## 🛠️ PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📸스크린샷 (선택)

---

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
